### PR TITLE
Enabling A2DP sink for modern bluetooth headphone support

### DIFF
--- a/modules/bare-metal/sound.nix
+++ b/modules/bare-metal/sound.nix
@@ -21,6 +21,8 @@
     # no need to redefine it in your config for now)
     #media-session.enable = true;
   };
+
+  # https://nixos.wiki/wiki/Bluetooth#Enabling_A2DP_Sink
   hardware.bluetooth.enable = true;
   hardware.bluetooth.settings = {
   General = {

--- a/modules/bare-metal/sound.nix
+++ b/modules/bare-metal/sound.nix
@@ -21,4 +21,12 @@
     # no need to redefine it in your config for now)
     #media-session.enable = true;
   };
+  hardware.bluetooth.enable = true;
+  hardware.bluetooth.settings = {
+  General = {
+    Enable = "Source,Sink,Media,Socket";
+  };
+
+
+};
 }


### PR DESCRIPTION
A2DP works and make the experience with a pair of Bose QC45 headphones much smoother.