### PR TITLE
Update tab space rules

### DIFF
--- a/modules/home-manager/myHome/neovim/init.lua
+++ b/modules/home-manager/myHome/neovim/init.lua
@@ -41,5 +41,7 @@ vim.api.nvim_create_autocmd("FileType", {
 -- Indents
 vim.api.nvim_set_option("tabstop", 4)
 vim.api.nvim_set_option("shiftwidth", 4)
+vim.api.nvim_set_option("softtabstop", 4)
+vim.api.nvim_set_option("expandtab", true)
 vim.api.nvim_set_option("smartindent", true)
 vim.cmd("filetype indent plugin on")


### PR DESCRIPTION
https://stackoverflow.com/a/1878983

One more thing, use `:retab` to convert existing tab to spaces. [vim.wikia.com/wiki/Converting_tabs_to_spaces](http://vim.wikia.com/wiki/Converting_tabs_to_spaces)